### PR TITLE
set lastDonation to seconds when resetting

### DIFF
--- a/scripts/update_fund.js
+++ b/scripts/update_fund.js
@@ -106,8 +106,8 @@ async function resetFund(date) {
   const data = {
     totalGiven: 0,
     totalGivers: 0,
-    // date in milliseconds
-    lastDonation: date,
+    // date in seconds
+    lastDonation: date / 1000,
   }
   await handleSet(data)
 }


### PR DESCRIPTION
When resetting the data in redis, I forgot that the timestamp used in the API calls expect seconds, and when updating the data we're also setting seconds to keep it consistent. Previously the reset function was setting it in milliseconds (which is standard timestamp storage), which is what caused the API calls to Stripe to not find any transactions. It was basically using an invalid date range.